### PR TITLE
fix: update repository url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "6.1.13",
   "repository": {
     "type": "git",
-    "url": "https://github.com/npm/node-tar.git"
+    "url": "https://github.com/isaacs/node-tar.git"
   },
   "scripts": {
     "genparse": "node scripts/generate-parse-fixtures.js",


### PR DESCRIPTION
`npm run lint` complains about the repository url being wrong
looks like npm was renamed to isaacs since in https://www.npmjs.com/package/tar it still displays https://github.com/npm/node-tar url, but it redirects to https://github.com/isaacs/node-tar