### PR TITLE
Change octal encoding in header

### DIFF
--- a/src/header.ts
+++ b/src/header.ts
@@ -381,7 +381,7 @@ const octalString = (num: number, size: number) =>
 const padOctal = (str: string, size: number) =>
   (str.length === size - 1
     ? str
-    : new Array(size - str.length - 1).join('0') + str + ' ') + '\0'
+    : new Array(size - str.length).join('0') + str) + '\0'
 
 const encDate = (
   buf: Buffer,


### PR DESCRIPTION
Hello,

I had compatibility problems with tar files generated by the node-tar library. 
In my case the archives were sent on proprietary embedded hardware, so it's quite specific.
On the other hand, the same archive generated with 7-zip or GNU tar worked perfectly. After observing the differences in the archives generated, it turned out that the significant difference was the way the numbers were encoded in the header.
![image](https://github.com/isaacs/node-tar/assets/6061005/c69480d1-f35e-4f2f-8bcc-f9b65e797111)

This point has already been covered in ticket [#28](https://github.com/isaacs/node-tar/issues/28).

My pull request corrects my specific problem and outputs archives encoded in the manner of 7-zip and GNU tar.

Hope this can help