### PR TITLE
docs(changelog): add missing v7 breaking change (node 10+ → 18+)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ## 7.0
 
+- Drop support for node <18
 - Rewrite in TypeScript, provide ESM and CommonJS hybrid
   interface
 - Add tree-shake friendly exports, like `import('tar/create')`


### PR DESCRIPTION
`package.json#engines` was changed from `>=10` to `>=18` in 7.0.0: https://github.com/isaacs/node-tar/commit/114c7ac4c24441cbe13de4aa46a864d46676c6bc#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R43-R44.

This is a huge breaking change that should be documented in release notes.